### PR TITLE
Feature Request: Allow custom bar name / description

### DIFF
--- a/docker/config.js
+++ b/docker/config.js
@@ -1,3 +1,5 @@
 window.srConfig = {}
 window.srConfig.API_URL = "$API_URL"
-window.srConfig.MEILISEARCH_URL = "$MEILISEARCH_URL"
+window.srConfig.MEILISEARCH_URL = "$MEILISEARCH_URL";
+window.srConfig.BAR_NAME = "$BAR_NAME";
+window.srConfig.DESCRIPTION = "$DESCRIPTION";

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -125,6 +125,7 @@ h3.form-section-title::before {
     margin-left: 10px;
     text-shadow: 3px 2px 0 rgba(0, 0, 0, .2);
     line-height: 0.9;
+    align-self: center;
 }
 
 .site-logo__title span {

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -9,8 +9,8 @@
                     </svg>
                 </div>
                 <h1 class="site-logo__title">
-                    Salt Rim
-                    <span>Your personal bar assistant</span>
+                    {{ name }}
+                    <span v-if="description">{{ description }}</span>
                 </h1>
             </RouterLink>
             <nav class="header-bar__navigation">
@@ -51,6 +51,14 @@ export default {
     data() {
         return {
             searchShown: false,
+        }
+    },
+    computed: {
+        name() {
+            return window.srConfig.BAR_NAME || 'Salt Rim';
+        },
+        description() {
+            return window.srConfig.DESCRIPTION;
         }
     },
     created() {


### PR DESCRIPTION
Implements #65 

By using config.js to set custom values, e.g.:

```javascript
window.srConfig = {}
window.srConfig.API_URL = "...";
window.srConfig.MEILISEARCH_URL = "...";
window.srConfig.BAR_NAME = "Dan's Bar"
//window.srConfig.DESCRIPTION = "Your personal bar assistant";
```

A user could further customise their bar's name.

"Salt Rim" links and version are still shown in the footer, so hopefully not a problem 🤞 

Screenshot:

![image](https://user-images.githubusercontent.com/4665754/226262558-174b19ed-f04d-4ef1-be84-d9520d21a577.png)
