### PR TITLE
chore: Updates from Alpine 3.15 to Alpine 3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:current-alpine3.15 as build
+FROM node:current-alpine3.20 AS build
 
 ARG BUILD_VERSION
 ENV BUILD_VERSION=${BUILD_VERSION:-develop}
@@ -12,7 +12,7 @@ RUN sed -i "s/{{VERSION}}/$BUILD_VERSION/g" ./docker/config.js
 
 RUN npm run build
 
-FROM nginx as prod
+FROM nginx AS prod
 
 COPY --from=build /app/dist /var/www/html
 


### PR DESCRIPTION
Alpine 3.15 reached end of life approximately 9 months ago.  This PR updates the base image to 3.20, without any noticeable issues in navigating the frontend.  This does increase the NPM version used to install, but I had no issues building.