### PR TITLE
Print functionality layout and quirks

### DIFF
--- a/src/components/Cocktail/CocktailDetails.vue
+++ b/src/components/Cocktail/CocktailDetails.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import { micromark } from 'micromark'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
@@ -58,6 +58,18 @@ const servings = ref(1)
 const currentUnit = ref(appState.defaultUnit)
 
 watch(() => route.params.id as string, fetchCocktail, { immediate: true })
+
+
+const printInterceptor = onMounted(() => {
+    window.addEventListener('keydown', (e) => {
+        if (e.key === "p" && e.ctrlKey === true) {
+            e.preventDefault();
+            const routeData = router.resolve({ name: 'print.cocktail', params: { id: (cocktail as any).slug } });
+            window.open(routeData.href, "_blank");
+        }
+    })
+})
+
 
 const sortedImages = computed(() => {
     if (!cocktail.value.images) {

--- a/src/components/Print/PrintCocktail.vue
+++ b/src/components/Print/PrintCocktail.vue
@@ -3,7 +3,7 @@
         <div class="print-first-row">
             <div v-if="cocktail.images && cocktail.images.length > 0" class="cocktail-print-image">
                 <img :src="cocktail.images[0].url" :alt="cocktail.images[0].copyright">
-                <span>{{ cocktail.images[0].copyright }}</span>
+                <span>© {{ cocktail.images[0].copyright }}</span>
             </div>
             <div class="cocktail-main-info">
                 <h1>{{ cocktail.name }}</h1>
@@ -166,10 +166,12 @@ ul, ol {
     display: flex;
     align-items: center;
     justify-content: center;
+    flex-direction: column;
 }
 
 .cocktail-print-image img {
     padding: 10px;
+    padding-bottom: 2px;
     max-height: 300px;
     max-width: 300px;
     display: block;


### PR DESCRIPTION
This small pull request slightly changes the print layout by placing the copyright on the bottom with a small © symbol.
![image](https://github.com/user-attachments/assets/db324ccf-eedb-4218-903b-78b58be6f174)

A new function also tries to intercept the print event while viewing a cocktail, redirecting the user to the print page.