### PR TITLE
Fix endless loading when deleting public cocktail link

### DIFF
--- a/src/components/Cocktail/PublicLinkDialog.vue
+++ b/src/components/Cocktail/PublicLinkDialog.vue
@@ -67,7 +67,7 @@ export default {
         generatePublicLink() {
             this.isLoading = true
             BarAssistantClient.savePublicCocktailLink(this.cocktail.id).then(resp => {
-                this.publicData = resp.data
+                this.publicData = resp.data || {}
                 this.isLoading = false
             }).catch(e => {
                 this.$toast.error(e.message)
@@ -77,7 +77,7 @@ export default {
         deletePublicLink() {
             this.isLoading = true
             BarAssistantClient.deletePublicCocktailLink(this.cocktail.id).then(resp => {
-                this.publicData = resp.data
+                this.publicData = resp.data || {}
                 this.isLoading = false
             }).catch(e => {
                 this.$toast.error(e.message)


### PR DESCRIPTION
This PR fixes a bug that occurs when deleting a cocktail public link, since the browser expects to find the public data of the cocktail which bar-assistant doesn't return.