### PR TITLE
Implement join bar link. Fix redirect bug in login flow. Fix bug in public menus link.

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -1,4 +1,15 @@
 class Utils {
+    static copyToClipboard(string) {
+        try {
+            const clipboard = navigator.clipboard;
+            clipboard.writeText(string);
+            return true
+        } catch (error) {
+            console.error('Failed to copy: ', error);
+            return false
+        }
+    }
+
     static decodeHtml(string) {
         var txt = document.createElement('textarea')
         txt.innerHTML = string
@@ -8,16 +19,16 @@ class Utils {
 
     static getRoleName(roleId) {
         switch (roleId) {
-        case 1:
-            return 'admin'
-        case 2:
-            return 'moderator'
-        case 3:
-            return 'general'
-        case 4:
-            return 'guest'
-        default:
-            return null
+            case 1:
+                return 'admin'
+            case 2:
+                return 'moderator'
+            case 3:
+                return 'general'
+            case 4:
+                return 'guest'
+            default:
+                return null
         }
 
     }

--- a/src/components/Auth/AuthLogin.vue
+++ b/src/components/Auth/AuthLogin.vue
@@ -99,13 +99,15 @@ export default {
                     appState.setUser(profileResp.data)
 
                     BarAssistantClient.getBars().then(barsResp => {
-                        if (barsResp.data.length == 1) {
-                            appState.setBar(barsResp.data[0])
-                            redirectPath = '/'
-                        } else {
-                            redirectPath = '/bars'
+                        if (redirectPath == undefined) {
+                            if (barsResp.data.length == 1) {
+                                appState.setBar(barsResp.data[0])
+                                redirectPath = '/'
+                            } else {
+                                redirectPath = '/bars'
+                            }
                         }
-
+                        
                         this.$router.push(redirectPath)
                     })
                 }).catch(e => {

--- a/src/components/Bar/BarIndex.vue
+++ b/src/components/Bar/BarIndex.vue
@@ -30,7 +30,10 @@
                             <DateFormatter :date="bar.created_at" />
                         </p>
                         <template v-if="bar.show_invite_code && bar.access.can_edit">
-                            <label class="form-label">{{ $t('bars.invite-code') }}:</label>
+                            <div class="bar__invite_label_container">
+                                <label class="form-label">{{ $t('bars.invite-code') }}:</label>
+                                <a href="#" @click.prevent="copyInviteLinkToClipboard(bar.invite_code)">Copy invite link</a>
+                            </div>
                             <p class="bar__invite_code">
                                 {{ bar.invite_code }}
                             </p>
@@ -100,7 +103,7 @@ export default {
         return {
             isLoading: false,
             bars: [],
-            showJoinDialog: false,
+            showJoinDialog: (this.$route.name == 'bars.join'), // If the route is bars.join then show the join dialog, otherwise don't
             showCreateDialog: false,
             appState: new AppState(),
         }
@@ -139,6 +142,13 @@ export default {
         this.refreshBars()
     },
     methods: {
+        copyInviteLinkToClipboard(invite_code) {
+            if (Utils.copyToClipboard(`${window.location.origin}/bars/join/${invite_code}`)) {
+                this.$toast.success(this.$t('bars.invite-link-copied'))
+            } else {
+                this.$toast.error(this.$t('bars.invite-link-error'))
+            }
+        },
         refreshBars() {
             this.isLoading = true
             BarAssistantClient.getBars().then(resp => {
@@ -270,6 +280,11 @@ export default {
     font-size: 0.8rem;
     margin-bottom: 0.5rem;
     color: var(--clr-gray-400);
+}
+
+.bar__invite_label_container {
+    display: flex;
+    justify-content: space-between;
 }
 
 .bar__invite_code {

--- a/src/components/Bar/BarIndex.vue
+++ b/src/components/Bar/BarIndex.vue
@@ -144,7 +144,7 @@ export default {
     methods: {
         copyInviteLinkToClipboard(invite_code) {
             if (Utils.copyToClipboard(`${window.location.origin}/bars/join/${invite_code}`)) {
-                this.$toast.success(this.$t('bars.invite-link-copied'))
+                this.$toast.default(this.$t('bars.invite-link-copied'))
             } else {
                 this.$toast.error(this.$t('bars.invite-link-error'))
             }

--- a/src/components/Bar/BarJoinDialog.vue
+++ b/src/components/Bar/BarJoinDialog.vue
@@ -14,7 +14,7 @@
         </div>
         <div class="dialog-actions" style="margin-top: 1rem">
             <button type="button" class="button button--outline" @click="$emit('dialogClosed')">{{ $t('cancel') }}</button>
-            <button type="submit" class="button button--dark">{{ $t('save') }}</button>
+            <button type="submit" class="button button--dark">{{ $t('join') }}</button>
         </div>
     </form>
 </template>

--- a/src/components/Bar/BarJoinDialog.vue
+++ b/src/components/Bar/BarJoinDialog.vue
@@ -30,7 +30,7 @@ export default {
     data() {
         return {
             isLoading: false,
-            inviteCode: null,
+            inviteCode: this.$route.params.invite || null,
         }
     },
     methods: {

--- a/src/components/Menu/MenuIndex.vue
+++ b/src/components/Menu/MenuIndex.vue
@@ -223,7 +223,7 @@ export default {
         refreshBar() {
             BarAssistantClient.getBar(this.appState.bar.id).then(resp => {
                 this.bar = resp.data
-                this.menu.url = `${window.location.origin}/bars/${this.bar.slug}`
+                this.menu.url = `${window.location.origin}/menu/${this.bar.slug}`
             }).catch(() => {
             })
         },

--- a/src/locales/messages/en-US.json
+++ b/src/locales/messages/en-US.json
@@ -139,6 +139,7 @@
   "field-supports-md": "This field supports markdown.",
   "cancel": "Cancel",
   "save": "Save",
+  "join": "Join",
   "recipe-information": "Recipe information",
   "additional-information": "Additional information",
   "source": "Source",

--- a/src/locales/messages/en-US.json
+++ b/src/locales/messages/en-US.json
@@ -375,6 +375,8 @@
     "join-notice": "To join existing bar you need an invite code. Ask the bar owner to send you one and paste it in the input below.",
     "invite-code": "Invite code",
     "toggle-invite-code": "Toggle invite code",
+    "invite-link-copied": "Invite link copied to clipboard",
+    "invite-link-error": "Unable to copy invite link to clipboard",
     "confirm-delete": "This will permanently delete bar with name \"{name}\".",
     "confirm-leave": "You will lose all your data in bar (\"{name}\") if you leave it.",
     "enable-invites": "Enable joining via invite code",

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -66,6 +66,14 @@ const router = createRouter({
             component: () => import('../views/PublicCocktailView.vue'),
             meta: { requiresAuth: false }
         },
+        // This new route allows bars with custom links such as 'form' or 'join' (which are already reserved routes) to be seen by the user.
+        // This is the new default route that is displayed with a public menu, but the user can still access the legacy route as to not break the QR codes.
+        {
+            path: '/menu/:slug',
+            name: 'menu.menu',
+            component: () => import('../views/MenuPublicView.vue'),
+            meta: { requiresAuth: false }
+        },
         {
             path: '/bars/:slug',
             name: 'bars.menu',
@@ -206,6 +214,11 @@ const router = createRouter({
                     path: '/bars/form',
                     name: 'bars.form',
                     component: () => import('../views/BarFormView.vue'),
+                },
+                {
+                    path: '/bars/join/:invite?',
+                    name: 'bars.join',
+                    component: () => import('../views/BarsView.vue'),
                 },
                 {
                     path: '/menu',

--- a/src/views/BarJoinView.vue
+++ b/src/views/BarJoinView.vue
@@ -1,0 +1,9 @@
+<script setup>
+import Bars from '../components/Bar/BarIndex.vue'
+</script>
+
+<template>
+    <main>
+        <Bars />
+    </main>
+</template>


### PR DESCRIPTION
## **This PR implements the feature and resolves #172; it fixes a bug which overwrites the redirect property in the login flow; it fixes a bug in the menu public link which doesn't allow certain menus to be seen.**

### Closes #172
A new route (/invite/join/:invite) allows the user to join a bar by supplying the invite code in an URL parameter. This will display the normal join bar dialog, with an automatically set invite code.
If the user doesn't specify :invite, the bar join dialog will open but no invite code will be set.
In the bars list, when the bar invite code is visible, a clickable link allows the user to copy the invite link to the clipboard.
![Bars ⋅ Bar Assistant](https://github.com/user-attachments/assets/0aeebeb2-2fcf-416a-99a0-8d20a8f8c356) 

Three strings are added to en_US.json, to tell the user if the link is successfully copied or not and for the button to actually join the bar (using "Join" instead of "Save" seemed more appropriate)

A new copy to clipboard function is also available in Utils.js

### Bug fixes

A new public menu route (/menu/:slug) would be the replacement for the old public menu route (/bars/:slug). This is because if a bar has its public link equivalent to "form" or "join", the hard-coded router route would overwrite them, rendering the menu useless.
To avoid invalidating QR codes, the old route (/bars/:slug) is still available as a legacy option. The bar settings and the generated QR codes are updated to work with the new route (/menu/:slug)

The login flow redirect is fixed, allowing users to be logged in and redirected to where they intended to go in the first place.

