### PR TITLE
Add link to cocktail to internal menu view

### DIFF
--- a/src/components/Menu/MenuIndex.vue
+++ b/src/components/Menu/MenuIndex.vue
@@ -49,7 +49,9 @@
                         <div class="drag-handle"></div>
                         <div class="menu-category__cocktail__content">
                             <div>
-                                <h4 class="sr-list-item-title">{{ item.name }}</h4>
+                                <RouterLink :to="{ name: 'cocktails.show', params: { id: item.id } }" class="sr-list-item-title">
+                                    <h4 class="sr-list-item-title menu-category__cocktail__content__title">{{ item.name }} </h4>
+                                </RouterLink>
                                 <p><span class="menu-item-type" :class="{'menu-item-type--ingredient': item.type == 'ingredient', 'menu-item-type--cocktail': item.type == 'cocktail'}">{{ item.type }}</span> {{ item.description }}</p>
                                 <a href="#" @click.prevent="copyCurrency(item.price.currency)">{{ t('menu.copy-currency') }}</a> &middot;
                                 <template v-if="item.type == 'cocktail'">
@@ -555,6 +557,10 @@ refreshBar()
     .menu-category__cocktail__content {
         flex-direction: column;
     }
+}
+
+.menu-category__cocktail__content__title {
+    margin-bottom: 0.5em;
 }
 
 .menu-category__cocktail__content__price {

--- a/src/components/Menu/MenuIndex.vue
+++ b/src/components/Menu/MenuIndex.vue
@@ -49,8 +49,8 @@
                         <div class="drag-handle"></div>
                         <div class="menu-category__cocktail__content">
                             <div>
-                                <RouterLink :to="{ name: 'cocktails.show', params: { id: item.id } }" class="sr-list-item-title">
-                                    <h4 class="sr-list-item-title menu-category__cocktail__content__title">{{ item.name }} </h4>
+                                <RouterLink :to="{ name: item.type == 'cocktail' ? 'cocktails.show' : 'ingredients.show', params: { id: item.id } }" class="sr-list-item-title">
+                                    <h4 class="sr-list-item-title menu-category__cocktail__content__title">{{ item.name }}</h4>
                                 </RouterLink>
                                 <p><span class="menu-item-type" :class="{'menu-item-type--ingredient': item.type == 'ingredient', 'menu-item-type--cocktail': item.type == 'cocktail'}">{{ item.type }}</span> {{ item.description }}</p>
                                 <a href="#" @click.prevent="copyCurrency(item.price.currency)">{{ t('menu.copy-currency') }}</a> &middot;


### PR DESCRIPTION
I'm proposing to add a link to the cocktail to the _internal_ menu view. I know that the public menu view includes a link to the cocktail page if it has been publicly shared, but I thought it would also be nice to include a link while one is managing the menu.

As implemented here, I've linked the title to the cocktail page and padded it slightly since it's now underlined. 

![image](https://github.com/user-attachments/assets/fc9838ea-5683-462f-986a-434b127c12af)

If preferred, I could reimplement as a "Show recipe" link at the bottom of the card, similar to the other links.

First time working with Vue, so just let me know if this change isn't up to snuff. Thanks for the project!
