### PR TITLE
Bulk Cocktail Upload via json

### DIFF
--- a/src/components/Cocktail/CocktailBulkImport.vue
+++ b/src/components/Cocktail/CocktailBulkImport.vue
@@ -1,0 +1,211 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import PageHeader from './../PageHeader.vue'
+import OverlayLoader from './../OverlayLoader.vue'
+import SaltRimDialog from './../Dialog/SaltRimDialog.vue'
+import { useI18n } from 'vue-i18n'
+import { parseUserJson, getFirstItemNames, importInChunks, type DuplicateAction, downloadJson, importSingle } from '@/composables/useBulkImport'
+import AppState from '@/AppState'
+
+const { t } = useI18n()
+const appState = new AppState()
+
+type Tab = 'upload' | 'paste'
+const activeTab = ref<Tab>('upload')
+const duplicateAction = ref<DuplicateAction>('none')
+
+const fileInput = ref<File | null>(null)
+const pasteInput = ref<string>('')
+const parseError = ref<string | null>(null)
+const parsedPayload = ref<any>(null)
+const isArray = ref(false)
+const isParsing = ref(false)
+
+const previewCount = computed(() => Array.isArray(parsedPayload.value) ? parsedPayload.value.length : (parsedPayload.value ? 1 : 0))
+const previewNames = computed(() => Array.isArray(parsedPayload.value) ? getFirstItemNames(parsedPayload.value, 10) : [])
+
+const isImporting = ref(false)
+const progressProcessed = ref(0)
+const totals = ref({ total: 0, created: 0, skipped: 0, overwritten: 0, failed: 0 })
+const results = ref<any[]>([])
+
+const largeFileWarning = computed(() => {
+    const f = fileInput.value
+    if (!f) return null
+    const tenMb = 10 * 1024 * 1024
+    return f.size > tenMb ? 'Selected file exceeds 10MB; parsing may be slow.' : null
+})
+
+function onFileChange(e: Event) {
+    const input = e.target as HTMLInputElement
+    if (input && input.files && input.files[0]) {
+        fileInput.value = input.files[0]
+    } else {
+        fileInput.value = null
+    }
+}
+
+async function handleParse() {
+    parseError.value = null
+    parsedPayload.value = null
+    isArray.value = false
+    isParsing.value = true
+    try {
+        if (activeTab.value === 'upload') {
+            if (!fileInput.value) throw new Error('Please select a JSON file')
+            const { payload, isArray: arr } = await parseUserJson(fileInput.value)
+            parsedPayload.value = payload
+            isArray.value = arr
+        } else {
+            if (!pasteInput.value || pasteInput.value.trim() === '') throw new Error('Please paste JSON payload')
+            const { payload, isArray: arr } = await parseUserJson(pasteInput.value)
+            parsedPayload.value = payload
+            isArray.value = arr
+        }
+    } catch (e: any) {
+        parseError.value = e?.message ?? 'Invalid JSON'
+    } finally {
+        isParsing.value = false
+    }
+}
+
+async function startImport() {
+    if (!parsedPayload.value) return
+    isImporting.value = true
+    progressProcessed.value = 0
+    totals.value = { total: isArray.value ? parsedPayload.value.length : 1, created: 0, skipped: 0, overwritten: 0, failed: 0 }
+    results.value = []
+
+    try {
+        if (!isArray.value) {
+            const single = await importSingle(parsedPayload.value, duplicateAction.value)
+            if (single.ok) {
+                totals.value.created = 1
+                results.value.push({ status: 'created', name: single.data?.name ?? null, index: 0 })
+            } else {
+                totals.value.failed = 1
+                results.value.push({ status: 'failed', name: parsedPayload.value?.recipe?.name ?? null, error: single.error, index: 0 })
+            }
+            progressProcessed.value = 1
+            return
+        }
+
+        const data = await importInChunks({
+            items: parsedPayload.value,
+            duplicateAction: duplicateAction.value,
+            chunkSize: 25,
+            concurrency: 1,
+            onProgress: (u) => {
+                progressProcessed.value = u.processed
+                totals.value = u.counts
+            },
+        })
+        results.value = data.items
+        totals.value = data.counts
+        progressProcessed.value = data.counts.total
+    } finally {
+        isImporting.value = false
+    }
+}
+
+const progressPercent = computed(() => {
+    if (totals.value.total === 0) return 0
+    return Math.round((progressProcessed.value / totals.value.total) * 100)
+})
+
+function exportFailed() {
+    if (!Array.isArray(parsedPayload.value)) return
+    const failed = results.value.filter(r => r.status === 'failed').map((r: any) => parsedPayload.value[r.index])
+    downloadJson('failed-cocktails.json', failed)
+}
+
+function goToCreated() {
+    window.location.href = '/cocktails'
+}
+</script>
+
+<template>
+    <form @submit.prevent>
+        <PageHeader>
+            {{ t('cocktail.import') }} — Bulk
+        </PageHeader>
+
+        <div class="block-container block-container--padded">
+            <div class="form-group">
+                <div class="tabs">
+                    <button type="button" class="button button--outline" :class="{ 'button--dark': activeTab==='upload' }" @click.prevent="activeTab='upload'">Upload JSON</button>
+                    <button type="button" class="button button--outline" :class="{ 'button--dark': activeTab==='paste' }" @click.prevent="activeTab='paste'">Paste JSON</button>
+                </div>
+            </div>
+
+            <div v-if="activeTab==='upload'" class="form-group">
+                <label class="form-label">JSON file:</label>
+                <input type="file" accept="application/json,.json" @change="onFileChange">
+                <p v-if="largeFileWarning" class="form-input-hint">{{ largeFileWarning }}</p>
+            </div>
+            <div v-else class="form-group">
+                <label class="form-label">JSON:</label>
+                <textarea v-model="pasteInput" class="form-input" rows="12" placeholder='[{ "recipe": { "name": "..." } }, ...]'></textarea>
+            </div>
+
+            <div class="form-group">
+                <label class="form-label">Duplicate strategy:</label>
+                <label class="form-checkbox"><input v-model="duplicateAction" type="radio" value="none"> <span>None</span></label>
+                <label class="form-checkbox"><input v-model="duplicateAction" type="radio" value="skip"> <span>Skip</span></label>
+                <label class="form-checkbox"><input v-model="duplicateAction" type="radio" value="overwrite"> <span>Overwrite</span></label>
+            </div>
+
+            <div style="display: flex; gap: var(--gap-size-2);">
+                <button type="button" class="button button--outline" @click.prevent="handleParse" :disabled="isParsing">
+                    <OverlayLoader v-if="isParsing" /> Parse
+                </button>
+                <button type="button" class="button button--dark" @click.prevent="startImport" :disabled="!parsedPayload || isParsing || isImporting">
+                    <OverlayLoader v-if="isImporting" /> Import
+                </button>
+            </div>
+
+            <div v-if="parseError" class="alert alert--warning" style="margin-top: 1rem;">
+                {{ parseError }}
+            </div>
+
+            <div v-if="parsedPayload" class="block-container block-container--padded" style="margin-top: 1rem;">
+                <h3 class="page-subtitle">Preview</h3>
+                <p>Detected: <strong>{{ isArray ? 'Array' : 'Single object' }}</strong>. Count: <strong>{{ previewCount }}</strong></p>
+                <ul v-if="isArray && previewNames.length > 0">
+                    <li v-for="(n, i) in previewNames" :key="i">{{ n }}</li>
+                </ul>
+                <p v-if="!isArray">This will use the single import path.</p>
+            </div>
+
+            <div v-if="totals.total > 0" class="block-container block-container--padded" style="margin-top: 1rem;">
+                <h3 class="page-subtitle">Progress</h3>
+                <div class="progress">
+                    <div class="progress__bar" :style="{ width: progressPercent + '%' }"></div>
+                </div>
+                <p>{{ progressProcessed }} / {{ totals.total }} — created: {{ totals.created }}, skipped: {{ totals.skipped }}, overwritten: {{ totals.overwritten }}, failed: {{ totals.failed }}</p>
+
+                <div class="form-actions" style="display:flex; gap: var(--gap-size-2);">
+                    <button type="button" class="button button--outline" :disabled="!Array.isArray(parsedPayload) || results.length === 0 || totals.failed === 0" @click.prevent="exportFailed">Export failed items (.json)</button>
+                    <button type="button" class="button button--dark" :disabled="totals.created === 0" @click.prevent="goToCreated">View created cocktails</button>
+                </div>
+
+                <div v-if="results.length > 0" class="results" style="margin-top: 1rem;">
+                    <h3 class="page-subtitle">Results</h3>
+                    <ul>
+                        <li v-for="(r, i) in results" :key="i">
+                            <strong>{{ r.name ?? ('Item #' + (r.index + 1)) }}</strong> — <span>{{ r.status }}</span>
+                            <div v-if="r.status === 'failed' && r.error" class="form-input-hint">{{ r.error }}</div>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </form>
+</template>
+
+<style scoped>
+.tabs { display: flex; gap: var(--gap-size-2); }
+.progress { width: 100%; background: var(--border-color); height: 8px; border-radius: 4px; overflow: hidden; }
+.progress__bar { height: 100%; background: var(--accent-color); transition: width 0.2s ease; }
+</style>
+

--- a/src/components/Cocktail/CocktailIndex.vue
+++ b/src/components/Cocktail/CocktailIndex.vue
@@ -3,6 +3,7 @@
         {{ $t('cocktail.cocktails') }}
         <template v-if="appState.isAdmin() || appState.isModerator() || appState.isGeneral()" #actions>
             <RouterLink class="button button--outline" :to="{ name: 'cocktails.scrape' }">{{ $t('cocktail.import') }}</RouterLink>
+            <RouterLink class="button button--outline" :to="{ name: 'cocktails.import.bulk' }">Bulk Import</RouterLink>
             <RouterLink class="button button--dark" :to="{ name: 'cocktails.form' }">{{ $t('cocktail.add') }}</RouterLink>
         </template>
     </PageHeader>

--- a/src/composables/__tests__/useBulkImport.test.ts
+++ b/src/composables/__tests__/useBulkImport.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { importInChunks } from '../useBulkImport'
+
+const originalFetch = global.fetch
+
+describe('importInChunks', () => {
+    beforeEach(() => {
+        // @ts-ignore
+        global.window = { srConfig: { API_URL: 'https://example.test' } }
+        // Minimal AppState mocks via module mock not trivial here; rely on headers not being validated by mocked fetch
+    })
+
+    it('chunks items and merges counts', async () => {
+        const responses = [
+            { data: { items: Array.from({ length: 2 }).map((_, i) => ({ status: 'created', index: i })), counts: { total: 2, created: 2, skipped: 0, overwritten: 0, failed: 0 } } },
+            { data: { items: Array.from({ length: 2 }).map((_, i) => ({ status: 'skipped', index: i })), counts: { total: 2, created: 0, skipped: 2, overwritten: 0, failed: 0 } } },
+        ]
+
+        global.fetch = vi.fn()
+            // @ts-ignore
+            .mockResolvedValueOnce({ ok: true, status: 200, json: async () => responses[0], headers: new Headers() })
+            // @ts-ignore
+            .mockResolvedValueOnce({ ok: true, status: 200, json: async () => responses[1], headers: new Headers() })
+
+        const items = [1, 2, 3, 4]
+        const res = await importInChunks({ items, duplicateAction: 'none', chunkSize: 2, concurrency: 2 })
+
+        expect(res.counts.total).toBe(4)
+        expect(res.counts.created).toBe(2)
+        expect(res.counts.skipped).toBe(2)
+        expect(res.items.length).toBe(4)
+    })
+
+    it('retries on 429 with backoff and then succeeds', async () => {
+        const retryHeaders = new Headers()
+        retryHeaders.set('Retry-After', '0')
+
+        global.fetch = vi.fn()
+            // @ts-ignore
+            .mockResolvedValueOnce({ ok: false, status: 429, headers: retryHeaders })
+            // @ts-ignore
+            .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ data: { items: [{ status: 'created', index: 0 }], counts: { total: 1, created: 1, skipped: 0, overwritten: 0, failed: 0 } } }), headers: new Headers() })
+
+        const items = [1]
+        const res = await importInChunks({ items, duplicateAction: 'none', chunkSize: 1, concurrency: 1 })
+
+        expect(res.counts.created).toBe(1)
+        expect(res.counts.failed).toBe(0)
+    })
+})
+
+afterAll(() => {
+    global.fetch = originalFetch
+})
+
+

--- a/src/composables/useBulkImport.ts
+++ b/src/composables/useBulkImport.ts
@@ -1,0 +1,215 @@
+import AppState from '@/AppState'
+
+export type DuplicateAction = 'none' | 'skip' | 'overwrite'
+
+export interface BulkImportCounts {
+    total: number
+    created: number
+    skipped: number
+    overwritten: number
+    failed: number
+}
+
+export interface BulkImportItemResult<TCocktailBasic = any> {
+    status: 'created' | 'skipped' | 'overwritten' | 'failed'
+    cocktail?: TCocktailBasic
+    name?: string | null
+    error?: string | null
+    index: number
+}
+
+export interface BulkImportResponse<TCocktailBasic = any> {
+    items: BulkImportItemResult<TCocktailBasic>[]
+    counts: BulkImportCounts
+}
+
+export interface ProgressUpdate {
+    processed: number
+    counts: BulkImportCounts
+}
+
+export interface ImportInChunksOptions<T = any> {
+    items: T[]
+    duplicateAction: DuplicateAction
+    chunkSize?: number
+    concurrency?: number
+    maxAttempts?: number
+    onProgress?: (update: ProgressUpdate) => void
+}
+
+export async function parseUserJson(input: string | File): Promise<{ payload: any, isArray: boolean }>
+{
+    const raw = typeof input === 'string' ? input : await input.text()
+    const parsed = JSON.parse(raw)
+    return { payload: parsed, isArray: Array.isArray(parsed) }
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function postImportChunk<T = any>(chunk: T[], duplicateAction: DuplicateAction, attempt = 0, maxAttempts = 5): Promise<BulkImportResponse>
+{
+    const appState = new AppState()
+    const token = appState.token ?? ''
+    const barId = appState.bar?.id ? String(appState.bar.id) : ''
+
+    const response = await fetch(`${window.srConfig.API_URL}/api/import/cocktail`, {
+        method: 'POST',
+        headers: {
+            'Authorization': `Bearer ${token}`,
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'Bar-Assistant-Bar-Id': barId,
+        },
+        body: JSON.stringify({ source: chunk, duplicate_actions: duplicateAction }),
+    })
+
+    if (response.status === 429) {
+        if (attempt >= maxAttempts) {
+            // Treat as failed chunk
+            return {
+                items: chunk.map((item: any, idx: number) => ({ status: 'failed', name: item?.recipe?.name ?? null, error: 'HTTP 429', index: idx })),
+                counts: { total: chunk.length, created: 0, skipped: 0, overwritten: 0, failed: chunk.length },
+            }
+        }
+
+        const retryAfterHeader = response.headers.get('Retry-After')
+        const retryAfter = retryAfterHeader ? Number(retryAfterHeader) : 1
+        const backoff = Math.min(1000 * Math.pow(2, attempt) + retryAfter * 1000, 15000)
+        await sleep(backoff)
+        return postImportChunk(chunk, duplicateAction, attempt + 1, maxAttempts)
+    }
+
+    if (!response.ok) {
+        return {
+            items: chunk.map((item: any, idx: number) => ({ status: 'failed', name: item?.recipe?.name ?? null, error: `HTTP ${response.status}` , index: idx })),
+            counts: { total: chunk.length, created: 0, skipped: 0, overwritten: 0, failed: chunk.length },
+        }
+    }
+
+    const json = await response.json()
+
+    // Backend returns single or bulk formats. Normalize.
+    if (json && json.data && json.data.items && json.data.counts) {
+        return json.data as BulkImportResponse
+    }
+
+    // Single response fallback
+    return {
+        items: [{ status: 'created', cocktail: json?.data ?? null, name: json?.data?.name ?? null, error: null, index: 0 }],
+        counts: { total: 1, created: 1, skipped: 0, overwritten: 0, failed: 0 },
+    }
+}
+
+export async function importInChunks<T = any>(options: ImportInChunksOptions<T>): Promise<BulkImportResponse>
+{
+    const {
+        items,
+        duplicateAction,
+        chunkSize = 25,
+        concurrency = 1,
+        maxAttempts = 5,
+        onProgress,
+    } = options
+
+    if (!Array.isArray(items) || items.length === 0) {
+        return { items: [], counts: { total: 0, created: 0, skipped: 0, overwritten: 0, failed: 0 } }
+    }
+
+    const effectiveChunkSize = Math.min(Math.max(chunkSize, 1), 500)
+    const chunks: T[][] = []
+    for (let i = 0; i < items.length; i += effectiveChunkSize) {
+        chunks.push(items.slice(i, i + effectiveChunkSize))
+    }
+
+    const totals: BulkImportCounts = { total: items.length, created: 0, skipped: 0, overwritten: 0, failed: 0 }
+    const allItems: BulkImportItemResult[] = []
+    let processed = 0
+
+    const queue = chunks.map((c, idx) => ({ payload: c, originalStartIndex: idx * effectiveChunkSize }))
+
+    async function worker(): Promise<void> {
+        while (queue.length > 0) {
+            const job = queue.shift()
+            if (!job) break
+
+            const data = await postImportChunk(job.payload, duplicateAction, 0, maxAttempts)
+
+            // Merge counts
+            totals.created += data.counts.created
+            totals.skipped += data.counts.skipped
+            totals.overwritten += data.counts.overwritten
+            totals.failed += data.counts.failed
+            processed += data.counts.total
+
+            // Normalize item indices to original indices
+            if (data.items && data.items.length > 0) {
+                const normalized = data.items.map((it, idx) => ({ ...it, index: (it?.index ?? idx) + job.originalStartIndex }))
+                allItems.push(...normalized)
+            }
+
+            onProgress && onProgress({ processed, counts: { ...totals } })
+        }
+    }
+
+    const workers = Array.from({ length: Math.min(concurrency, chunks.length) }).map(() => worker())
+    await Promise.all(workers)
+
+    return { items: allItems, counts: totals }
+}
+
+export function getFirstItemNames(items: any[], max = 10): string[]
+{
+    const names: string[] = []
+    for (let i = 0; i < items.length && names.length < max; i++) {
+        const it = items[i]
+        const name = it?.recipe?.name ?? it?.name ?? null
+        names.push(name ? String(name) : `Unnamed item #${i + 1}`)
+    }
+    return names
+}
+
+export function downloadJson(filename: string, data: unknown): void
+{
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    document.body.appendChild(a)
+    a.click()
+    URL.revokeObjectURL(url)
+    document.body.removeChild(a)
+}
+
+export async function importSingle<T = any>(source: T, duplicateAction: DuplicateAction): Promise<{ ok: true, data: any } | { ok: false, error: string }>
+{
+    const appState = new AppState()
+    const token = appState.token ?? ''
+    const barId = appState.bar?.id ? String(appState.bar.id) : ''
+
+    try {
+        const response = await fetch(`${window.srConfig.API_URL}/api/import/cocktail`, {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${token}`,
+                'Accept': 'application/json',
+                'Content-Type': 'application/json',
+                'Bar-Assistant-Bar-Id': barId,
+            },
+            body: JSON.stringify({ source, duplicate_actions: duplicateAction }),
+        })
+
+        if (!response.ok) {
+            return { ok: false, error: `HTTP ${response.status}` }
+        }
+
+        const json = await response.json()
+        return { ok: true, data: json?.data }
+    } catch (e: any) {
+        return { ok: false, error: e?.message ?? 'Unknown error' }
+    }
+}
+
+

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -115,6 +115,12 @@ const router = createRouter({
                     meta: { requiresBar: true },
                 },
                 {
+                    path: '/cocktails/import/bulk',
+                    name: 'cocktails.import.bulk',
+                    component: () => import('../views/CocktailsBulkImportView.vue'),
+                    meta: { requiresBar: true },
+                },
+                {
                     path: '/cocktails/:id',
                     name: 'cocktails.show',
                     component: () => import('../views/CocktailView.vue'),

--- a/src/views/CocktailsBulkImportView.vue
+++ b/src/views/CocktailsBulkImportView.vue
@@ -1,0 +1,11 @@
+<script setup>
+import CocktailBulkImport from '../components/Cocktail/CocktailBulkImport.vue'
+</script>
+
+<template>
+    <main>
+        <CocktailBulkImport />
+    </main>
+    
+</template>
+


### PR DESCRIPTION
This is a feature add that is supported by a [corresponding PR](https://github.com/karlomikus/bar-assistant/pull/524) in bar-assistant

The goal is to improve cocktail import function to support bulk uploads. To accomplish this, I've updated API documentation to reflect changes in request structure and response format, added tests for various import scenarios including creation, and also added the ability to skip, overwrite, and handle partial failures.

attached are some screenshots from vue-salt-rim frontend

<img width="878" height="381" alt="Screenshot 2025-08-24 at 11 23 50 AM" src="https://github.com/user-attachments/assets/2aed7d5e-9627-4ac2-be4a-dbc4f149213e" />
<img width="878" height="580" alt="Screenshot 2025-08-24 at 11 23 55 AM" src="https://github.com/user-attachments/assets/83339b85-51d8-438c-b295-5de8939769d0" />

note: skip duplicates was chosen for this screenshot
<img width="878" height="864" alt="Screenshot 2025-08-24 at 11 25 00 AM" src="https://github.com/user-attachments/assets/9e5fc16d-a3d2-4b28-8e3e-3abe27d39af4" />



