### PR TITLE
Improve translation fluency

### DIFF
--- a/src/components/Bar/BarForm.vue
+++ b/src/components/Bar/BarForm.vue
@@ -4,7 +4,7 @@
         <PageHeader>
             {{ $t('bars.bar') }}
         </PageHeader>
-        <h3 class="form-section-title">{{ $t('information') }}</h3>
+        <h3 class="form-section-title">{{ $t('bars.information') }}</h3>
         <div class="block-container block-container--padded">
             <div class="form-group">
                 <label class="form-label form-label--required" for="name">{{ $t('name') }}:</label>
@@ -64,7 +64,7 @@
             </div>
             <div class="form-group" v-if="bar.id">
                 <div class="alert alert--info">
-                    <p>This action helps synchronize your search data with the actual data. It also recalculates all cocktail ABVs and ingredient materialized paths. You can run this action manually, but it is limited to once every 10 minutes. Regular execution is not necessary, you should only run this if you notice problems with incorrect data.</p>
+                    <p>{{ $t('bars.optimization-description') }}</p>
                     <button type="button" class="button button--dark" @click="runBarOptimize"><OverlayLoader v-if="isOptimizationRunning" />{{ $t('bars.optimize') }}</button>
                 </div>
             </div>

--- a/src/components/Shelf/ShelfIndex.vue
+++ b/src/components/Shelf/ShelfIndex.vue
@@ -346,7 +346,7 @@ refreshShelf()
                 <ListItemContainer tag="RouterLink" v-for="ingredient in stats.most_popular_ingredients" :key="ingredient.id" :to="{ name: 'ingredients.show', params: { id: ingredient.slug } }">
                     <template #content>
                         <h5 class="sr-list-item-title">{{ ingredient.name }}</h5>
-                        <p>{{ ingredient.cocktails_count }} {{ $t('cocktail.cocktails') }}</p>
+                        <p>{{ $t('n-cocktails', ingredient.cocktails_count) }}</p>
                     </template>
                 </ListItemContainer>
             </div>

--- a/src/locales/messages/en-US.json
+++ b/src/locales/messages/en-US.json
@@ -10,6 +10,7 @@
     "zh-CN": "Chinese (Simplified)",
     "nl-NL": "Netherlands",
     "cs-CZ": "Czech",
+    "fi-FI": "Finnish",
     "help": "Help with translations"
   },
   "shelf": {
@@ -370,6 +371,7 @@
   "bars": {
     "title": "Bars",
     "bar": "Bar",
+    "information": "Information",
     "join": "Join a bar",
     "add": "Create bar",
     "add-success": "Bar \"{name}\" succesfully created",
@@ -404,6 +406,7 @@
       "data": "No default data"
     },
     "optimization-started": "Started bar optimization",
+    "optimization-description": "This action helps synchronize your search data with the actual data. It also recalculates all cocktail ABVs and ingredient materialized paths. You can run this action manually, but it is limited to once every 10 minutes. Regular execution is not necessary, you should only run this if you notice problems with incorrect data.",
     "optimize": "Optimize bar",
     "confirm-optimization": "This will run bar optimizations",
     "sync-data": "Synchronize data",
@@ -498,6 +501,7 @@
   "top-rated-cocktails": "Top rated cocktails",
   "most-popular-ingredients": "Popular ingredients",
   "votes": "Votes",
+  "n-cocktails": "No cocktails | {n} cocktail | {n} cocktails",
   "recommended-ingredients": "Recommended ingredients",
   "menu": {
     "title": "Menu",

--- a/src/locales/messages/fi-FI.json
+++ b/src/locales/messages/fi-FI.json
@@ -10,6 +10,7 @@
     "zh-CN": "Kiina (yksinkertaistettu)",
     "nl-NL": "Hollanti",
     "cs-CZ": "Tšekki",
+    "fi-FI": "Suomi",
     "help": "Auta käännöksissä"
   },
   "shelf": {
@@ -370,6 +371,7 @@
   "bars": {
     "title": "Baarit",
     "bar": "Baari",
+    "information": "Tiedot",
     "join": "Liity baariin",
     "add": "Luo baari",
     "add-success": "Baari \"{name}\" luotu onnistuneesti",
@@ -404,6 +406,7 @@
       "data": "Aloita puhtaalta pöydältä"
     },
     "optimization-started": "Aloitettu baarin optimointi",
+    "optimization-description": "Tämä toiminto synkronoi hakupalveluun ajantasaiset tiedot tietokannasta. Se myös laskee uudelleen kaikkien juomien alkoholipitoisuudet sekä päivittää ainesosien keskinäiset suhteet. Voit aloittaa toiminnon suorittamisen käsin, mutta suoritus on rajattu yhteen kertaan 10 minuutissa. Toiminnon säännöllinen suorittaminen ei ole tarpeellista. Tee se vain jos törmäät ongelmiin tiedoissa.",
     "optimize": "Optimoi baari",
     "confirm-optimization": "Tämä suorittaa baarin tietojen optimoinnin",
     "sync-data": "Synkronoi tiedot",
@@ -498,6 +501,7 @@
   "top-rated-cocktails": "Parhaan arvion saaneet juomat",
   "most-popular-ingredients": "Paljon käytetyt ainesosat",
   "votes": "Arvioita",
+  "n-cocktails": "Ei juomia | {n} juoma | {n} juomaa",
   "recommended-ingredients": "Suositellut ainesosat",
   "menu": {
     "title": "Juomalista",

--- a/src/locales/messages/sv-SE.json
+++ b/src/locales/messages/sv-SE.json
@@ -10,6 +10,7 @@
     "zh-CN": "Chinese (Simplified)",
     "nl-NL": "Netherlands",
     "cs-CZ": "Czech",
+    "fi-FI": "Finska",
     "help": "Hjälp till att översätta"
   },
   "shelf": {


### PR DESCRIPTION
While translating this very useful app in Finnish I stumbled upon a couple of difficult situations, so here's something to address that.

I attempted to keep English texts unchanged except for the front page now displaying `1 cocktail`/`n cocktails` rather than `1..n Cocktails`, with capitalization changed as well.