### PR TITLE
Fix service worker issue when using SSO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,16 +32,16 @@ RUN chmod +x /usr/local/bin/entrypoint
 
 CMD [ "/usr/local/bin/entrypoint" ]
 
-#FROM node:latest AS dev
-#
-#WORKDIR /app
-#
-#COPY package*.json ./
-#
-#RUN npm install
-#
-#COPY . .
-#
-#EXPOSE 5173
-#
-#CMD ["npm", "run", "dev"]
+FROM node:latest AS dev
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG BUILD_VERSION
 ENV BUILD_VERSION=${BUILD_VERSION:-develop}
 
 WORKDIR /app
-COPY package*.json .
+COPY package*.json ./
 RUN npm install
 COPY . .
 
@@ -32,16 +32,16 @@ RUN chmod +x /usr/local/bin/entrypoint
 
 CMD [ "/usr/local/bin/entrypoint" ]
 
-FROM node:latest AS dev
-
-WORKDIR /app
-
-COPY package*.json ./
-
-RUN npm install
-
-COPY . .
-
-EXPOSE 5173
-
-CMD ["npm", "run", "dev"]
+#FROM node:latest AS dev
+#
+#WORKDIR /app
+#
+#COPY package*.json ./
+#
+#RUN npm install
+#
+#COPY . .
+#
+#EXPOSE 5173
+#
+#CMD ["npm", "run", "dev"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -62,7 +62,7 @@ export default defineConfig({
         }
     }), VitePWA({
         workbox: {
-            navigateFallbackDenylist: [/^\/bar/]
+            navigateFallbackDenylist: [/^\/bar/,/^\/api\//]
         },
         manifest: manifest,
         registerType: 'autoUpdate',


### PR DESCRIPTION
Fix for a problem I was experiencing with SSO:
* When using SSO with Authentik, 
* while behind a reverse proxy that routes / to salt-rim and the /api prefix to bar-assistant, and
* while the service worker is already loaded (from having visited the site recently)

The service worker would intercept the login redirect request, preventing SSO login from working correctly.

I've added the /api prefix to the navigateFallbackDenyLists in Vite to prevent this behavior.

Tested in my local environment, and I haven't noticed any unexpected problems.