### PR TITLE
Optionally hide "My Shelf" and associated features.

### DIFF
--- a/src/AppState.ts
+++ b/src/AppState.ts
@@ -14,6 +14,7 @@ class AppState {
     rememberMe: boolean
     isPasswordLoginEnabled: boolean
     isAiEnabled: boolean
+    isUserShelfEnabled: boolean
     _key: string
 
     constructor() {
@@ -25,6 +26,7 @@ class AppState {
         this.rememberMe = false
         this.isPasswordLoginEnabled = true
         this.isAiEnabled = false
+        this.isUserShelfEnabled = true
         this.bar = {} as Bar
         this.user = {} as Profile
 
@@ -98,9 +100,10 @@ class AppState {
         this._updateState()
     }
 
-    setServerSettings(isPasswordLoginEnabled: boolean, isAiEnabled: boolean) {
+    setServerSettings(isPasswordLoginEnabled: boolean, isAiEnabled: boolean, isUserShelfEnabled: boolean) {
         this.isPasswordLoginEnabled = isPasswordLoginEnabled
         this.isAiEnabled = isAiEnabled
+        this.isUserShelfEnabled = isUserShelfEnabled
         this._updateState()
     }
 
@@ -177,6 +180,7 @@ class AppState {
             this.user = newState.user
             this.isPasswordLoginEnabled = newState.isPasswordLoginEnabled
             this.isAiEnabled = newState.isAiEnabled
+            this.isUserShelfEnabled = newState.isUserShelfEnabled ?? true
         }
     }
 }

--- a/src/api/api.d.ts
+++ b/src/api/api.d.ts
@@ -4218,6 +4218,11 @@ export interface components {
              * @example true
              */
             is_ai_enabled: boolean;
+            /**
+             * @description Whether the per-user shelf feature is enabled
+             * @example true
+             */
+            is_user_shelf_enabled: boolean;
         };
         ShoppingListRequest: {
             ingredients: {

--- a/src/components/Cocktail/CocktailGridItem.vue
+++ b/src/components/Cocktail/CocktailGridItem.vue
@@ -8,7 +8,7 @@
                 <div v-if="cocktail.in_bar_shelf" class="cocktail-badge" :title="$t('in_bar_shelf')">
                     <IconBarShelf></IconBarShelf>
                 </div>
-                <div v-if="cocktail.in_shelf" class="cocktail-badge" :title="$t('in_your_shelf')">
+                <div v-if="cocktail.in_shelf && appState.isUserShelfEnabled" class="cocktail-badge" :title="$t('in_your_shelf')">
                     <IconUserShelf></IconUserShelf>
                 </div>
                 <div v-if="cocktail.public_id" class="cocktail-badge" :title="$t('is_public')">
@@ -39,10 +39,13 @@ import IconFavorite from '../Icons/IconFavorite.vue';
 import IconBarShelf from '../Icons/IconBarShelf.vue';
 import IconUserShelf from '../Icons/IconUserShelf.vue';
 import IconPublicLink from '../Icons/IconPublicLink.vue';
+import AppState from '@/AppState';
 import type { components } from '@/api/api';
 import { computed, onMounted, useTemplateRef, type ComponentPublicInstance } from 'vue';
 
 type Cocktail = components['schemas']['Cocktail']
+
+const appState = new AppState()
 
 const props = defineProps<{
     cocktail: Cocktail,

--- a/src/components/Cocktail/CocktailIndex.vue
+++ b/src/components/Cocktail/CocktailIndex.vue
@@ -35,7 +35,7 @@
                         </SaltRimDialog>
                     </Refinement>
                     <Refinement v-if="refineCollections.length > 0" id="collection" v-model="activeFilters.collection_id" :title="$t('collections.title')" :refinements="refineCollections" @change="updateRouterPath"></Refinement>
-                    <Refinement v-if="refineUserShelves.length > 0" id="user_shelves" v-model="activeFilters.user_shelves" :title="$t('public-shelves')" :refinements="refineUserShelves" @change="updateRouterPath"></Refinement>
+                    <Refinement v-if="refineUserShelves.length > 0 && appState.isUserShelfEnabled" id="user_shelves" v-model="activeFilters.user_shelves" :title="$t('public-shelves')" :refinements="refineUserShelves" @change="updateRouterPath"></Refinement>
                     <Refinement id="users" v-model="activeFilters.created_user_id" :searchable="true" :title="$t('user-recipes')" :refinements="refineUsers" @change="updateRouterPath"></Refinement>
                     <Refinement id="main-ingredient" v-model="activeFilters.main_ingredient_id" :searchable="true" :title="$t('ingredient.main')" :refinements="refineMainIngredients" @change="updateRouterPath"></Refinement>
                     <Refinement id="method" v-model="activeFilters.cocktail_method_id" :title="$t('method.title')" :refinements="refineMethods" @change="updateRouterPath"></Refinement>
@@ -44,7 +44,7 @@
                     <Refinement id="glass" v-model="activeFilters.glass_id" :title="$t('glass-type.title')" :refinements="refineGlasses" @change="updateRouterPath"></Refinement>
                     <Refinement id="total-ingredients" v-model="activeFilters.total_ingredients" :title="$t('total.ingredients')" :refinements="refineIngredientsCount" type="radio" @change="updateRouterPath"></Refinement>
                     <Refinement id="missing-bar-ingredients" v-model="activeFilters.missing_bar_ingredients" :title="$t('missing-ingredients') + ' (' + $t('bars.bar') + ')'" :refinements="refineMissingBarIngredients" type="radio" @change="updateRouterPath"></Refinement>
-                    <Refinement id="missing-ingredients" v-model="activeFilters.missing_ingredients" :title="$t('missing-ingredients') + ' (' + $t('shelf.title') + ')'" :refinements="refineMissingIngredients" type="radio" @change="updateRouterPath"></Refinement>
+                    <Refinement v-if="appState.isUserShelfEnabled" id="missing-ingredients" v-model="activeFilters.missing_ingredients" :title="$t('missing-ingredients') + ' (' + $t('shelf.title') + ')'" :refinements="refineMissingIngredients" type="radio" @change="updateRouterPath"></Refinement>
                     <Refinement id="user-rating" v-model="activeFilters.user_rating_min" :title="$t('your-rating')" :refinements="refineRatings" type="radio" @change="updateRouterPath"></Refinement>
                     <Refinement id="avg-rating" v-model="activeFilters.average_rating_min" :title="$t('avg-rating')" :refinements="refineRatings" type="radio" @change="updateRouterPath"></Refinement>
                     <button class="button button--dark sm-show" type="button" @click="showRefinements = false">{{ $t('cancel') }}</button>
@@ -161,8 +161,9 @@ export default {
         MenuAddDialog,
     },
     data() {
+        const appState = new AppState()
         return {
-            appState: new AppState(),
+            appState,
             showCreateNewCollectionDialog: false,
             isLoading: false,
             showRefinements: false,
@@ -182,10 +183,14 @@ export default {
                 global: [
                     { name: this.$t('bar_shelf.cocktails'), active: false, id: 'bar_shelf' },
                     { name: this.$t('bar_shelf.locked_cocktails'), active: false, id: 'locked_bar_cocktails' },
-                    { name: this.$t('shelf.cocktails'), active: false, id: 'on_shelf' },
+                    ...(appState.isUserShelfEnabled
+                        ? [{ name: this.$t('shelf.cocktails'), active: false, id: 'on_shelf' }]
+                        : []),
                     { name: this.$t('my-favorites'), active: false, id: 'favorites' },
                     { name: this.$t('cocktail.shared'), active: false, id: 'is_public' },
-                    { name: this.$t('shelf.locked_cocktails'), active: false, id: 'locked_user_cocktails' },
+                    ...(appState.isUserShelfEnabled
+                        ? [{ name: this.$t('shelf.locked_cocktails'), active: false, id: 'locked_user_cocktails' }]
+                        : []),
                 ],
                 abv: [
                     { name: this.$t('non-alcoholic'), min: null, max: 2, id: 'abv_non_alcoholic' },

--- a/src/components/Ingredient/IngredientDetails.vue
+++ b/src/components/Ingredient/IngredientDetails.vue
@@ -43,7 +43,7 @@
                             </a>
                         </template>
                     </ToggleIngredientBarShelf>
-                    <ToggleIngredientShelf v-if="ingredient.in_shelf !== undefined" :ingredient="ingredient" v-model="ingredient.in_shelf">
+                    <ToggleIngredientShelf v-if="ingredient.in_shelf !== undefined && appState.isUserShelfEnabled" :ingredient="ingredient" v-model="ingredient.in_shelf">
                         <template v-slot="{ isLoading, inList, toggle }">
                             <a href="#" class="block-container block-container--hover shelf-actions__action" @click.prevent="toggle">
                                 <div>

--- a/src/components/Ingredient/IngredientGridItem.vue
+++ b/src/components/Ingredient/IngredientGridItem.vue
@@ -13,7 +13,7 @@
                 <ToggleIngredientBarShelf v-if="ingredient.in_bar_shelf !== undefined" :ingredient="ingredient" v-model="ingredient.in_bar_shelf"></ToggleIngredientBarShelf>
                 &middot;
             </template>
-            <template v-else>
+            <template v-else-if="appState.isUserShelfEnabled">
                 <ToggleIngredientShelf v-if="ingredient.in_shelf !== undefined" :ingredient="ingredient" v-model="ingredient.in_shelf"></ToggleIngredientShelf>
                 &middot;
             </template>
@@ -38,9 +38,9 @@ const props = defineProps<{
     ingredient: Ingredient
 }>()
 
-const showBarShelf = computed(() => {
-    const appState = new AppState();
+const appState = new AppState()
 
+const showBarShelf = computed(() => {
     return appState.isAdmin() || appState.isModerator()
 })
 

--- a/src/components/Ingredient/IngredientIndex.vue
+++ b/src/components/Ingredient/IngredientIndex.vue
@@ -127,7 +127,9 @@ const availableRefinements = ref({
     categories: [] as Ingredient[],
     global: [
         { name: t('bar-shelf-ingredients'), active: false, id: 'bar_shelf' },
-        { name: t('shelf-ingredients'), active: false, id: 'on_shelf' },
+        ...(appState.isUserShelfEnabled
+            ? [{ name: t('shelf-ingredients'), active: false, id: 'on_shelf' }]
+            : []),
         { name: t('shopping-list-ingredients'), active: false, id: 'on_shopping_list' },
         { name: t('used-as-main-ingredient'), active: false, id: 'main_ingredients' },
         { name: t('ingredient.complex'), active: false, id: 'complex' },

--- a/src/components/Settings/ProfileForm.vue
+++ b/src/components/Settings/ProfileForm.vue
@@ -68,7 +68,7 @@
                     </table>
                 </div>
             </template>
-            <template v-if="appState.bar.id">
+            <template v-if="appState.bar.id && appState.isUserShelfEnabled">
                 <h3 class="form-section-title">{{ $t('bars.bar') }}</h3>
                 <div class="block-container block-container--padded">
                     <div class="form-group">

--- a/src/components/Shelf/ShelfIndex.vue
+++ b/src/components/Shelf/ShelfIndex.vue
@@ -146,7 +146,7 @@ refreshShelf()
                         <RouterLink :to="{ name: 'ingredients' }">{{ $t('total.ingredients') }}</RouterLink>
                     </p>
                 </div>
-                <div class="block-container stats__stat">
+                <div v-if="appState.isUserShelfEnabled" class="block-container stats__stat">
                     <h3>{{ stats.total_shelf_ingredients }}</h3>
                     <p>
                         <RouterLink :to="{ name: 'ingredients', query: { 'filter[on_shelf]': 'true' } }">{{ $t('shelf-ingredients') }}</RouterLink>
@@ -164,7 +164,7 @@ refreshShelf()
                         <RouterLink :to="{ name: 'cocktails', query: { 'filter[favorites]': 'true' } }">{{ $t('favorited-cocktails') }}</RouterLink>
                     </p>
                 </div>
-                <div class="block-container stats__stat">
+                <div v-if="appState.isUserShelfEnabled" class="block-container stats__stat">
                     <h3>{{ stats.total_shelf_cocktails }}</h3>
                     <p>
                         <RouterLink :to="{ name: 'cocktails', query: { 'filter[on_shelf]': 'true' } }">{{ $t('shelf.cocktails') }}</RouterLink>
@@ -216,7 +216,7 @@ refreshShelf()
                 </template>
             </EmptyState>
         </div>
-        <div class="shelf-grid__col">
+        <div v-if="appState.isUserShelfEnabled" class="shelf-grid__col">
             <OverlayLoader v-if="loaders.recommendedCocktails"></OverlayLoader>
             <h3 class="page-subtitle">{{ $t('shelf.recommended-cocktails') }}</h3>
             <div class="salt-rim-list" v-if="recommendedCocktails.length > 0">
@@ -301,8 +301,10 @@ refreshShelf()
                     <template #content>
                         <h5 class="sr-list-item-title">{{ ingredient.name }}</h5>
                         <p>
-                            <ToggleIngredientShelf v-if="ingredient.in_shelf !== undefined" :ingredient="ingredient" v-model="ingredient.in_shelf"></ToggleIngredientShelf>
-                            &middot;
+                            <template v-if="appState.isUserShelfEnabled">
+                                <ToggleIngredientShelf v-if="ingredient.in_shelf !== undefined" :ingredient="ingredient" v-model="ingredient.in_shelf"></ToggleIngredientShelf>
+                                &middot;
+                            </template>
                             <ToggleIngredientShoppingCart v-if="ingredient.in_shopping_list !== undefined" :ingredient="ingredient" v-model="ingredient.in_shopping_list"></ToggleIngredientShoppingCart>
                         </p>
                     </template>
@@ -360,7 +362,7 @@ refreshShelf()
                 </template>
             </EmptyState>
         </div>
-        <div class="shelf-grid__col">
+        <div v-if="appState.isUserShelfEnabled" class="shelf-grid__col">
             <h3 class="page-subtitle">{{ $t('recommended-ingredients') }}</h3>
             <RecommendedIngredients v-if="stats?.total_cocktails > 0" :stats="stats"></RecommendedIngredients>
             <EmptyState v-else>

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -33,7 +33,7 @@ const useAuth = async (token: string): Promise<string> => {
     ]);
 
     if (serverInfo?.data) {
-        appState.setServerSettings(serverInfo.data.is_password_login_enabled, serverInfo.data.is_ai_enabled)
+        appState.setServerSettings(serverInfo.data.is_password_login_enabled, serverInfo.data.is_ai_enabled, serverInfo.data.is_user_shelf_enabled)
     }
 
     if (bars?.data?.length == 1) {


### PR DESCRIPTION
# What

This change hides per-user ingredient shelves and associated features from the user, if the API server has been configured with `ENABLE_USER_SHELF=false`

There's a corresponding PR for the API server to support presenting this preference: https://github.com/karlomikus/bar-assistant/pull/585

It has no effect on the app otherwise, and the features may still be accessed via the API if hidden.

# Why

I've found per-user ingredient shelves to have no utility for myself or my housemates, and we all find that having multiple shelves is confusing, frequently resulting in cocktail searches and recipe recommendations not functioning correctly due to ingredients being distrubted between different lists.

The functionality already present in "Bar Shelf" serves our needs better, and I've seen that some other users have expressed similar confusion:

* https://github.com/karlomikus/bar-assistant/discussions/430
* https://github.com/karlomikus/bar-assistant/issues/519

# Usage

For default behavior, in which each user has their own "My Shelf" in addition to a shared global "Bar Shelf", make no changes.

To hide "My Shelf" and associated features like "Cocktails I Can Make" (leaving "Bar Shelf" and "Bar Shelf Cocktails" unaffected), add the following environment variable to `docker-compose.yaml` for the api server.

```
    environment:
      - ENABLE_USER_SHELF=false  # Default true
```

# Schema

The status of this setting is read from the `api/server/version` endpoint as the `data: is_user_shelf_enabled` boolean.