### PR TITLE
Fix escaped HTML entities not rendering as Markdown (e.g. `>`)

### DIFF
--- a/src/components/Cocktail/CocktailDetails.vue
+++ b/src/components/Cocktail/CocktailDetails.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from "vue";
 import { useEventListener } from "@vueuse/core";
-import { micromark } from "micromark";
+import { useMarkdown } from "@/composables/useMarkdown";
 import { useRoute, useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 import { useTitle } from "@/composables/title";
@@ -111,7 +111,7 @@ const parsedInstructions = computed(() => {
         return null;
     }
 
-    return micromark(cocktail.value.instructions);
+    return useMarkdown(cocktail.value.instructions);
 });
 
 const parsedDescription = computed(() => {
@@ -119,7 +119,7 @@ const parsedDescription = computed(() => {
         return null;
     }
 
-    return micromark(cocktail.value.description);
+    return useMarkdown(cocktail.value.description);
 });
 
 const parsedGarnish = computed(() => {
@@ -127,7 +127,7 @@ const parsedGarnish = computed(() => {
         return null;
     }
 
-    return micromark(cocktail.value.garnish);
+    return useMarkdown(cocktail.value.garnish);
 });
 
 const calculatedCalories = computed(() => {

--- a/src/components/Cocktail/CocktailRecipeImage.vue
+++ b/src/components/Cocktail/CocktailRecipeImage.vue
@@ -36,7 +36,7 @@
 
 <script setup lang="ts">
 import { ref, computed } from "vue";
-import { micromark } from "micromark";
+import { useMarkdown } from "@/composables/useMarkdown";
 import AppState from "@/AppState";
 import CocktailIngredientShare from "@/components/Cocktail/CocktailIngredientShare.vue";
 import type { components } from "@/api/api";
@@ -70,7 +70,7 @@ const parsedDescription = computed(() => {
         return null;
     }
 
-    return micromark(props.cocktail.description);
+    return useMarkdown(props.cocktail.description);
 });
 
 const parsedInstructions = computed(() => {
@@ -78,7 +78,7 @@ const parsedInstructions = computed(() => {
         return null;
     }
 
-    return micromark(props.cocktail.instructions);
+    return useMarkdown(props.cocktail.instructions);
 });
 
 const parsedGarnish = computed(() => {
@@ -86,7 +86,7 @@ const parsedGarnish = computed(() => {
         return null;
     }
 
-    return micromark(props.cocktail.garnish);
+    return useMarkdown(props.cocktail.garnish);
 });
 </script>
 

--- a/src/components/Ingredient/IngredientDetails.vue
+++ b/src/components/Ingredient/IngredientDetails.vue
@@ -258,7 +258,7 @@ import { useRoute, useRouter } from "vue-router";
 import { unitHandler } from "@/composables/useUnits";
 import CalculatorRender from "../Calculator/CalculatorRender.vue";
 import OverlayLoader from "@/components/OverlayLoader.vue";
-import { micromark } from "micromark";
+import { useMarkdown } from "@/composables/useMarkdown";
 import PageHeader from "../PageHeader.vue";
 import BarAssistantClient from "@/api/BarAssistantClient";
 import ToggleIngredientShoppingCart from "@/components/ToggleIngredientShoppingCart.vue";
@@ -397,7 +397,7 @@ const parsedDescription = computed(() => {
         return null;
     }
 
-    return micromark(ingredient.value.description);
+    return useMarkdown(ingredient.value.description);
 });
 
 const createdDate = computed(() => {

--- a/src/components/Print/PrintCocktail.vue
+++ b/src/components/Print/PrintCocktail.vue
@@ -54,7 +54,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { micromark } from "micromark";
+import { useMarkdown } from "@/composables/useMarkdown";
 import { unitHandler } from "@/composables/useUnits";
 import type { CocktailPrintModel, CocktailPrintIngredient } from "./types";
 
@@ -80,21 +80,21 @@ const parsedDescription = computed(() => {
     if (!props.cocktail.description) {
         return null;
     }
-    return micromark(props.cocktail.description);
+    return useMarkdown(props.cocktail.description);
 });
 
 const parsedInstructions = computed(() => {
     if (!props.cocktail.instructions) {
         return null;
     }
-    return micromark(props.cocktail.instructions);
+    return useMarkdown(props.cocktail.instructions);
 });
 
 const parsedGarnish = computed(() => {
     if (!props.cocktail.garnish) {
         return null;
     }
-    return micromark(props.cocktail.garnish);
+    return useMarkdown(props.cocktail.garnish);
 });
 
 function ingredientAmount(ing: CocktailPrintIngredient): string {

--- a/src/components/Print/__tests__/PrintCocktail.test.ts
+++ b/src/components/Print/__tests__/PrintCocktail.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import PrintCocktail from "../PrintCocktail.vue";
+import type { CocktailPrintModel } from "../types";
+
+function makeCocktail(overrides: Partial<CocktailPrintModel> = {}): CocktailPrintModel {
+    return {
+        name: "Old Fashioned",
+        description: null,
+        instructions: "Stir with ice.",
+        garnish: null,
+        images: [],
+        ingredients: [],
+        ...overrides,
+    };
+}
+
+function mountPrint(overrides: Partial<CocktailPrintModel> = {}) {
+    return mount(PrintCocktail, {
+        props: { cocktail: makeCocktail(overrides) },
+        global: {
+            mocks: {
+                $t: (key: string) => key,
+            },
+        },
+    });
+}
+
+describe("PrintCocktail markdown rendering", () => {
+    it("renders an API-escaped blockquote as a <blockquote>, not a <p>", () => {
+        const wrapper = mountPrint({
+            description: "Created by X at Bartender's Bar.\n\n&gt; Everybody knows the significance",
+        });
+
+        const blockquote = wrapper.find("blockquote");
+        expect(blockquote.exists()).toBe(true);
+        expect(blockquote.text()).toContain("Everybody knows the significance");
+        expect(wrapper.text()).not.toContain("&gt;");
+    });
+
+    it("renders &#039; as an apostrophe", () => {
+        const wrapper = mountPrint({
+            description: "Bartender&#039;s Bar",
+        });
+
+        expect(wrapper.text()).toContain("Bartender's Bar");
+    });
+
+    it("still renders a blockquote for already clean input", () => {
+        const wrapper = mountPrint({
+            description: "> Everybody knows the significance",
+        });
+
+        expect(wrapper.find("blockquote").exists()).toBe(true);
+    });
+
+    it("decodes escaped instructions and garnish too", () => {
+        const wrapper = mountPrint({
+            instructions: "&gt; Stir, don&#039;t shake",
+            garnish: "&gt; Orange twist",
+        });
+
+        expect(wrapper.findAll("blockquote")).toHaveLength(2);
+        expect(wrapper.text()).toContain("Stir, don't shake");
+        expect(wrapper.text()).toContain("Orange twist");
+    });
+
+    it("renders nothing for a null description", () => {
+        const wrapper = mountPrint({ description: null });
+
+        expect(wrapper.find(".cocktail-main-info div").exists()).toBe(false);
+        expect(wrapper.find(".cocktail-main-info h1").text()).toBe("Old Fashioned");
+    });
+
+    it("renders nothing for an empty description", () => {
+        const wrapper = mountPrint({ description: "" });
+
+        expect(wrapper.find(".cocktail-main-info div").exists()).toBe(false);
+    });
+});

--- a/src/components/Public/PublicCocktailDetails.vue
+++ b/src/components/Public/PublicCocktailDetails.vue
@@ -72,7 +72,7 @@
 import { computed, ref, watch } from "vue";
 import type { components } from "@/api/api";
 import { useRouter } from "vue-router";
-import { micromark } from "micromark";
+import { useMarkdown } from "@/composables/useMarkdown";
 import CocktailIngredient from "./PublicCocktailIngredient.vue";
 import CocktailRecipeScaler from "./../Cocktail/CocktailRecipeScaler.vue";
 import AppState from "@/AppState";
@@ -97,15 +97,15 @@ const props = defineProps<{
 }>();
 
 const parsedDescription = computed(() => {
-    return props.cocktail.description ? micromark(props.cocktail.description) : "";
+    return props.cocktail.description ? useMarkdown(props.cocktail.description) : "";
 });
 
 const parsedInstructions = computed(() => {
-    return props.cocktail.instructions ? micromark(props.cocktail.instructions) : "";
+    return props.cocktail.instructions ? useMarkdown(props.cocktail.instructions) : "";
 });
 
 const parsedGarnish = computed(() => {
-    return props.cocktail.garnish ? micromark(props.cocktail.garnish) : "";
+    return props.cocktail.garnish ? useMarkdown(props.cocktail.garnish) : "";
 });
 
 const mainImage = computed(() => {

--- a/src/composables/__tests__/useMarkdown.test.ts
+++ b/src/composables/__tests__/useMarkdown.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { useMarkdown } from "../useMarkdown";
+
+describe("useMarkdown", () => {
+    it("renders an HTML-escaped blockquote as a blockquote", () => {
+        const result = useMarkdown("&gt; Everybody knows the significance");
+
+        expect(result).toContain("<blockquote>");
+        expect(result).toContain("Everybody knows the significance");
+    });
+
+    it("renders an already clean blockquote as a blockquote", () => {
+        const result = useMarkdown("> Everybody knows the significance");
+
+        expect(result).toContain("<blockquote>");
+    });
+
+    it("decodes numeric apostrophe entities", () => {
+        const result = useMarkdown("Bartender&#039;s Bar");
+
+        expect(result).not.toContain("&#039;");
+        expect(result).toMatch(/Bartender(?:'|&#x27;|&#39;|&apos;)s Bar/);
+    });
+
+    it("renders an HTML-escaped autolink as a link", () => {
+        const result = useMarkdown("&lt;https://barassistant.app&gt;");
+
+        expect(result).toContain('<a href="https://barassistant.app">');
+    });
+
+    it("returns an empty string for empty input", () => {
+        expect(useMarkdown("")).toBe("");
+    });
+
+    it("still escapes raw HTML after decoding", () => {
+        const result = useMarkdown("&lt;script&gt;alert(1)&lt;/script&gt;");
+
+        expect(result).not.toContain("<script>");
+        expect(result).toContain("&lt;script&gt;");
+    });
+});

--- a/src/composables/useMarkdown.ts
+++ b/src/composables/useMarkdown.ts
@@ -1,0 +1,6 @@
+import { micromark } from "micromark";
+import { useHtmlDecode } from "./useHtmlDecode";
+
+export function useMarkdown(input: string): string {
+    return micromark(useHtmlDecode(input));
+}


### PR DESCRIPTION
This PR fixes the issue #409. The API escapes the markdown fields, so `>` arrives as `&gt;`. `micromark` resolves character references after block parsing, so a leading `&gt;` never opens a blockquote. The edit forms already decode these fields; the display path did not.

The PR adds a `useMarkdown()` composable that decodes HTML entities before parsing the string using `micromark`.

`PublicBarShow` and `CalculatorRender` still use the plain `micromark()` — `description` fields are not escaped for these (see [Public/BarResource.php#L43](https://github.com/karlomikus/bar-assistant/blob/548d416f746d5144a0536d99f12c6937f82ccfe5/app/Http/Resources/Public/BarResource.php#L43) and [CalculatorResource.php#L43](https://github.com/karlomikus/bar-assistant/blob/548d416f746d5144a0536d99f12c6937f82ccfe5/app/Http/Resources/CalculatorResource.php#L43)). `useGitHubReleases` also uses the plain `micromark()` since GitHub bodies are not escaped.

### To clarify

- Perhaps descriptions for the bars and calculators should be escaped as well in the API for uniformity? Then this PR needs to be adjusted to decode in these components as well.