### PR TITLE
fix(pwa): do not let serviceworker intercept meilisearch

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -62,7 +62,7 @@ export default defineConfig({
         }
     }), VitePWA({
         workbox: {
-            navigateFallbackDenylist: [/^\/bar/,/^\/api\//]
+            navigateFallbackDenylist: [/^\/bar/,/^\/api/, /^\/search/]
         },
         manifest: manifest,
         registerType: 'autoUpdate',


### PR DESCRIPTION
hey @karlomikus, I am hyped for barassistant v6 and salt-rim v5 already! Unfortunately after the upgrade I noticed the frontend kept showing something like meilisearch cannot be reached. I was confused and navigated to /search/version and was presented a blank page. After reloading without cache, I got some meili error saying the auth header was missing. 

I am using the reverse proxy sublocation setup as described [here](https://docs.barassistant.app/setup/#nginx-config-example-with-subfolders). I believe /search must be added to the manifest as well to stop the serviceworker from intercepting traffic